### PR TITLE
Do not parse dates when creating csv either

### DIFF
--- a/src/convert.jl
+++ b/src/convert.jl
@@ -17,6 +17,7 @@ function process_dataset(
   df = CSV.File(
       path,
       header=false,
+      typemap=Dict(Date=>String, DateTime=>String),
       missingstrings=["", "NA", "?", "*", "#DIV/0!"],
       truestrings=["T", "t", "TRUE", "true", "y", "yes"],
       falsestrings=["F", "f", "FALSE", "false", "n", "no"];


### PR DESCRIPTION
To complete https://github.com/JackDunnNZ/UCIData.jl/pull/22, I realized the raw data convert needs the same type restrictions as well