### PR TITLE
include files at precompilation time rather than runtime

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UCIData"
 uuid = "2dacb708-9dd8-11e9-1001-07df1c52a9e4"
 author = ["Interpretable AI <info@interpretable.ai>"]
-version = "1.0.4"
+version = "1.0.5"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/UCIData.jl
+++ b/src/UCIData.jl
@@ -3,11 +3,21 @@ module UCIData
 
 import CSV
 using CategoricalArrays
-using DataDeps
+
 using DataFrames
 using DelimitedFiles
 using Dates
+using DataDeps: DataDeps
 
+# Our `register` will push a registration function into `REGISTER`.
+# Then at `__init__` time, we will call these to register them
+# with DataDeps. This allows us to call `register` at precompilation
+# time, so we can include separate files each with a `register` call,
+# but do the registration at runtime, as DataDeps requires.
+const REGISTRY = []
+function register(args...; kwargs...)
+    push!(REGISTRY, () -> DataDeps.register(args...; kwargs...))
+end
 
 const DATA_DIR = joinpath(@__DIR__, "data")
 
@@ -42,6 +52,12 @@ end
 for datasettype in list_dataset_types()
     for dataset in list_datasets(datasettype)
       include(joinpath(DATA_DIR, datasettype, "$dataset.jl"))
+    end
+end
+
+function __init__()
+    for f in REGISTRY
+        f()
     end
 end
 

--- a/src/UCIData.jl
+++ b/src/UCIData.jl
@@ -7,7 +7,7 @@ using CategoricalArrays
 using DataFrames
 using DelimitedFiles
 using Dates
-using DataDeps: DataDeps, DataDep, @datadep_str
+using DataDeps: DataDeps, DataDep, @datadep_str, unpack
 
 # Our `register` will push a registration function into `REGISTER`.
 # Then at `__init__` time, we will call these to register them

--- a/src/UCIData.jl
+++ b/src/UCIData.jl
@@ -7,7 +7,7 @@ using CategoricalArrays
 using DataFrames
 using DelimitedFiles
 using Dates
-using DataDeps: DataDeps
+using DataDeps: DataDeps, DataDep, @datadep_str
 
 # Our `register` will push a registration function into `REGISTER`.
 # Then at `__init__` time, we will call these to register them

--- a/src/UCIData.jl
+++ b/src/UCIData.jl
@@ -39,12 +39,10 @@ function list_datasets(datasettype)
   map(x -> splitext(x)[1], datasets)
 end
 
-function __init__()
-  for datasettype in list_dataset_types()
+for datasettype in list_dataset_types()
     for dataset in list_datasets(datasettype)
       include(joinpath(DATA_DIR, datasettype, "$dataset.jl"))
     end
-  end
 end
 
 

--- a/src/data/classification/acute-inflammations-1.jl
+++ b/src/data/classification/acute-inflammations-1.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "acute-inflammations-1",
   "http://archive.ics.uci.edu/ml/datasets/Acute+Inflammations",

--- a/src/data/classification/acute-inflammations-2.jl
+++ b/src/data/classification/acute-inflammations-2.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "acute-inflammations-2",
   "http://archive.ics.uci.edu/ml/datasets/Acute+Inflammations",

--- a/src/data/classification/arrhythmia.jl
+++ b/src/data/classification/arrhythmia.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "arrhythmia",
   "http://archive.ics.uci.edu/ml/datasets/Arrhythmia",

--- a/src/data/classification/balance-scale.jl
+++ b/src/data/classification/balance-scale.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "balance-scale",
   "http://archive.ics.uci.edu/ml/datasets/Balance+Scale",

--- a/src/data/classification/balloons-a.jl
+++ b/src/data/classification/balloons-a.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "balloons-a",
   "http://archive.ics.uci.edu/ml/datasets/Balloons",

--- a/src/data/classification/balloons-b.jl
+++ b/src/data/classification/balloons-b.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "balloons-b",
   "http://archive.ics.uci.edu/ml/datasets/Balloons",

--- a/src/data/classification/balloons-c.jl
+++ b/src/data/classification/balloons-c.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "balloons-c",
   "http://archive.ics.uci.edu/ml/datasets/Balloons",

--- a/src/data/classification/balloons-d.jl
+++ b/src/data/classification/balloons-d.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "balloons-d",
   "http://archive.ics.uci.edu/ml/datasets/Balloons",

--- a/src/data/classification/banknote-authentication.jl
+++ b/src/data/classification/banknote-authentication.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "banknote-authentication",
   "http://archive.ics.uci.edu/ml/datasets/banknote+authentication",

--- a/src/data/classification/blood-transfusion-service-center.jl
+++ b/src/data/classification/blood-transfusion-service-center.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "blood-transfusion-service-center",
   "http://archive.ics.uci.edu/ml/datasets/Blood+Transfusion+Service+Center",

--- a/src/data/classification/breast-cancer-wisconsin-diagnostic.jl
+++ b/src/data/classification/breast-cancer-wisconsin-diagnostic.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "breast-cancer-wisconsin-diagnostic",
   "http://archive.ics.uci.edu/ml/datasets/Breast+Cancer+Wisconsin+%28Diagnostic%29",

--- a/src/data/classification/breast-cancer-wisconsin-original.jl
+++ b/src/data/classification/breast-cancer-wisconsin-original.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "breast-cancer-wisconsin-original",
   "http://archive.ics.uci.edu/ml/datasets/Breast+Cancer+Wisconsin+%28Original%29",

--- a/src/data/classification/breast-cancer-wisconsin-prognostic.jl
+++ b/src/data/classification/breast-cancer-wisconsin-prognostic.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "breast-cancer-wisconsin-prognostic",
   "http://archive.ics.uci.edu/ml/datasets/Breast+Cancer+Wisconsin+%28Prognostic%29",

--- a/src/data/classification/breast-cancer.jl
+++ b/src/data/classification/breast-cancer.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "breast-cancer",
   "http://archive.ics.uci.edu/ml/datasets/Breast+Cancer",

--- a/src/data/classification/car-evaluation.jl
+++ b/src/data/classification/car-evaluation.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "car-evaluation",
   "http://archive.ics.uci.edu/ml/datasets/Car+Evaluation",

--- a/src/data/classification/chess-king-rook-vs-king-pawn.jl
+++ b/src/data/classification/chess-king-rook-vs-king-pawn.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "chess-king-rook-vs-king-pawn",
   "http://archive.ics.uci.edu/ml/datasets/Chess+%28King-Rook+vs.+King-Pawn%29",

--- a/src/data/classification/chess-king-rook-vs-king.jl
+++ b/src/data/classification/chess-king-rook-vs-king.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "chess-king-rook-vs-king",
   "http://archive.ics.uci.edu/ml/datasets/Chess+%28King-Rook+vs.+King%29",

--- a/src/data/classification/climate-model-simulation-crashes.jl
+++ b/src/data/classification/climate-model-simulation-crashes.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "climate-model-simulation-crashes",
   "http://archive.ics.uci.edu/ml/datasets/Climate+Model+Simulation+Crashes",

--- a/src/data/classification/cnae-9.jl
+++ b/src/data/classification/cnae-9.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "cnae-9",
   "http://archive.ics.uci.edu/ml/datasets/CNAE-9",

--- a/src/data/classification/congressional-voting-records.jl
+++ b/src/data/classification/congressional-voting-records.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "congressional-voting-records",
   "http://archive.ics.uci.edu/ml/datasets/Congressional+Voting+Records",

--- a/src/data/classification/connectionist-bench-sonar.jl
+++ b/src/data/classification/connectionist-bench-sonar.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "connectionist-bench-sonar",
   "http://archive.ics.uci.edu/ml/datasets/Connectionist+Bench+%28Sonar%2C+Mines+vs.+Rocks%29",

--- a/src/data/classification/connectionist-bench.jl
+++ b/src/data/classification/connectionist-bench.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "connectionist-bench",
   "https://archive.ics.uci.edu/ml/datasets/Connectionist+Bench+(Vowel+Recognition+-+Deterding+Data)",

--- a/src/data/classification/contraceptive-method-choice.jl
+++ b/src/data/classification/contraceptive-method-choice.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "contraceptive-method-choice",
   "http://archive.ics.uci.edu/ml/datasets/Contraceptive+Method+Choice",

--- a/src/data/classification/credit-approval.jl
+++ b/src/data/classification/credit-approval.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "credit-approval",
   "http://archive.ics.uci.edu/ml/datasets/Credit+Approval",

--- a/src/data/classification/cylinder-bands.jl
+++ b/src/data/classification/cylinder-bands.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "cylinder-bands",
   "http://archive.ics.uci.edu/ml/datasets/Cylinder+Bands",

--- a/src/data/classification/dermatology.jl
+++ b/src/data/classification/dermatology.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "dermatology",
   "http://archive.ics.uci.edu/ml/datasets/Dermatology",

--- a/src/data/classification/echocardiogram.jl
+++ b/src/data/classification/echocardiogram.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "echocardiogram",
   "http://archive.ics.uci.edu/ml/datasets/Echocardiogram",

--- a/src/data/classification/ecoli.jl
+++ b/src/data/classification/ecoli.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "ecoli",
   "http://archive.ics.uci.edu/ml/datasets/Ecoli",

--- a/src/data/classification/fertility.jl
+++ b/src/data/classification/fertility.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "fertility",
   "http://archive.ics.uci.edu/ml/datasets/Fertility",

--- a/src/data/classification/flags.jl
+++ b/src/data/classification/flags.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "flags",
   "http://archive.ics.uci.edu/ml/datasets/Flags",

--- a/src/data/classification/glass-identification.jl
+++ b/src/data/classification/glass-identification.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "glass-identification",
   "http://archive.ics.uci.edu/ml/datasets/Glass+Identification",

--- a/src/data/classification/haberman-survival.jl
+++ b/src/data/classification/haberman-survival.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "haberman-survival",
   "http://archive.ics.uci.edu/ml/datasets/Haberman%27s+Survival",

--- a/src/data/classification/hayes-roth.jl
+++ b/src/data/classification/hayes-roth.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "hayes-roth",
   "http://archive.ics.uci.edu/ml/datasets/Hayes-Roth",

--- a/src/data/classification/heart-disease-cleveland.jl
+++ b/src/data/classification/heart-disease-cleveland.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "heart-disease-cleveland",
   "http://archive.ics.uci.edu/ml/datasets/Heart+Disease",

--- a/src/data/classification/heart-disease-hungarian.jl
+++ b/src/data/classification/heart-disease-hungarian.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "heart-disease-hungarian",
   "http://archive.ics.uci.edu/ml/datasets/Heart+Disease",

--- a/src/data/classification/heart-disease-switzerland.jl
+++ b/src/data/classification/heart-disease-switzerland.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "heart-disease-switzerland",
   "http://archive.ics.uci.edu/ml/datasets/Heart+Disease",

--- a/src/data/classification/heart-disease-va.jl
+++ b/src/data/classification/heart-disease-va.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "heart-disease-va",
   "http://archive.ics.uci.edu/ml/datasets/Heart+Disease",

--- a/src/data/classification/hepatitis.jl
+++ b/src/data/classification/hepatitis.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "hepatitis",
   "http://archive.ics.uci.edu/ml/datasets/Hepatitis",

--- a/src/data/classification/hill-valley-noise.jl
+++ b/src/data/classification/hill-valley-noise.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "hill-valley-noise",
   "http://archive.ics.uci.edu/ml/datasets/Hill-Valley",

--- a/src/data/classification/hill-valley.jl
+++ b/src/data/classification/hill-valley.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "hill-valley",
   "http://archive.ics.uci.edu/ml/datasets/Hill-Valley",

--- a/src/data/classification/horse-colic.jl
+++ b/src/data/classification/horse-colic.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "horse-colic",
   "http://archive.ics.uci.edu/ml/datasets/Horse+Colic",

--- a/src/data/classification/image-segmentation.jl
+++ b/src/data/classification/image-segmentation.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "image-segmentation",
   "http://archive.ics.uci.edu/ml/datasets/Image+Segmentation",

--- a/src/data/classification/indian-liver-patient.jl
+++ b/src/data/classification/indian-liver-patient.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "indian-liver-patient",
   "http://archive.ics.uci.edu/ml/datasets/ILPD+%28Indian+Liver+Patient+Dataset%29",

--- a/src/data/classification/ionosphere.jl
+++ b/src/data/classification/ionosphere.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "ionosphere",
   "http://archive.ics.uci.edu/ml/datasets/Ionosphere",

--- a/src/data/classification/iris.jl
+++ b/src/data/classification/iris.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "iris",
   "http://archive.ics.uci.edu/ml/datasets/Iris",

--- a/src/data/classification/lenses.jl
+++ b/src/data/classification/lenses.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "lenses",
   "http://archive.ics.uci.edu/ml/datasets/Lenses",

--- a/src/data/classification/letter-recognition.jl
+++ b/src/data/classification/letter-recognition.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "letter-recognition",
   "http://archive.ics.uci.edu/ml/datasets/Letter+Recognition",

--- a/src/data/classification/libras-movement.jl
+++ b/src/data/classification/libras-movement.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "libras-movement",
   "http://archive.ics.uci.edu/ml/datasets/Libras+Movement",

--- a/src/data/classification/lung-cancer.jl
+++ b/src/data/classification/lung-cancer.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "lung-cancer",
   "http://archive.ics.uci.edu/ml/datasets/Lung+Cancer",

--- a/src/data/classification/magic-gamma-telescope.jl
+++ b/src/data/classification/magic-gamma-telescope.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "magic-gamma-telescope",
   "http://archive.ics.uci.edu/ml/datasets/MAGIC+Gamma+Telescope",

--- a/src/data/classification/mammographic-mass.jl
+++ b/src/data/classification/mammographic-mass.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "mammographic-mass",
   "https://archive.ics.uci.edu/ml/datasets/Mammographic+Mass",

--- a/src/data/classification/monks-problems-1.jl
+++ b/src/data/classification/monks-problems-1.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "monks-problems-1",
   "http://archive.ics.uci.edu/ml/datasets/MONK%27s+Problems",

--- a/src/data/classification/monks-problems-2.jl
+++ b/src/data/classification/monks-problems-2.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "monks-problems-2",
   "http://archive.ics.uci.edu/ml/datasets/MONK%27s+Problems",

--- a/src/data/classification/monks-problems-3.jl
+++ b/src/data/classification/monks-problems-3.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "monks-problems-3",
   "http://archive.ics.uci.edu/ml/datasets/MONK%27s+Problems",

--- a/src/data/classification/mushroom.jl
+++ b/src/data/classification/mushroom.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "mushroom",
   "http://archive.ics.uci.edu/ml/datasets/Mushroom",

--- a/src/data/classification/nursery.jl
+++ b/src/data/classification/nursery.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "nursery",
   "http://archive.ics.uci.edu/ml/datasets/Nursery",

--- a/src/data/classification/optical-recognition-handwritten-digits.jl
+++ b/src/data/classification/optical-recognition-handwritten-digits.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "optical-recognition-handwritten-digits",
   "http://archive.ics.uci.edu/ml/datasets/Optical+Recognition+of+Handwritten+Digits",

--- a/src/data/classification/ozone-level-detection-eight.jl
+++ b/src/data/classification/ozone-level-detection-eight.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "ozone-level-detection-eight",
   "https://archive.ics.uci.edu/ml/datasets/Ozone+Level+Detection",

--- a/src/data/classification/ozone-level-detection-one.jl
+++ b/src/data/classification/ozone-level-detection-one.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "ozone-level-detection-one",
   "https://archive.ics.uci.edu/ml/datasets/Ozone+Level+Detection",

--- a/src/data/classification/parkinsons.jl
+++ b/src/data/classification/parkinsons.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "parkinsons",
   "http://archive.ics.uci.edu/ml/datasets/Parkinsons",

--- a/src/data/classification/pen-based-recognition-handwritten-digits.jl
+++ b/src/data/classification/pen-based-recognition-handwritten-digits.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "pen-based-recognition-handwritten-digits",
   "http://archive.ics.uci.edu/ml/datasets/Pen-Based+Recognition+of+Handwritten+Digits",

--- a/src/data/classification/planning-relax.jl
+++ b/src/data/classification/planning-relax.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "planning-relax",
   "http://archive.ics.uci.edu/ml/datasets/Planning+Relax",

--- a/src/data/classification/poker-hand.jl
+++ b/src/data/classification/poker-hand.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "poker-hand",
   "http://archive.ics.uci.edu/ml/datasets/Poker+Hand",

--- a/src/data/classification/post-operative-patient.jl
+++ b/src/data/classification/post-operative-patient.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "post-operative-patient",
   "http://archive.ics.uci.edu/ml/datasets/Post-Operative+Patient",

--- a/src/data/classification/qsar-biodegradation.jl
+++ b/src/data/classification/qsar-biodegradation.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "qsar-biodegradation",
   "http://archive.ics.uci.edu/ml/datasets/QSAR+biodegradation",

--- a/src/data/classification/seeds.jl
+++ b/src/data/classification/seeds.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "seeds",
   "http://archive.ics.uci.edu/ml/datasets/seeds",

--- a/src/data/classification/seismic-bumps.jl
+++ b/src/data/classification/seismic-bumps.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "seismic-bumps",
   "https://archive.ics.uci.edu/ml/datasets/seismic-bumps",

--- a/src/data/classification/shuttle-landing-control.jl
+++ b/src/data/classification/shuttle-landing-control.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "shuttle-landing-control",
   "http://archive.ics.uci.edu/ml/datasets/Shuttle+Landing+Control",

--- a/src/data/classification/skin-segmentation.jl
+++ b/src/data/classification/skin-segmentation.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "skin-segmentation",
   "http://archive.ics.uci.edu/ml/datasets/Skin+Segmentation",

--- a/src/data/classification/soybean-large.jl
+++ b/src/data/classification/soybean-large.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "soybean-large",
   "http://archive.ics.uci.edu/ml/datasets/Soybean+%28Large%29",

--- a/src/data/classification/soybean-small.jl
+++ b/src/data/classification/soybean-small.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "soybean-small",
   "http://archive.ics.uci.edu/ml/datasets/Soybean+%28Large%29",

--- a/src/data/classification/spambase.jl
+++ b/src/data/classification/spambase.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "spambase",
   "http://archive.ics.uci.edu/ml/datasets/Spambase",

--- a/src/data/classification/spect-heart.jl
+++ b/src/data/classification/spect-heart.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "spect-heart",
   "http://archive.ics.uci.edu/ml/datasets/SPECT+Heart",

--- a/src/data/classification/spectf-heart.jl
+++ b/src/data/classification/spectf-heart.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "spectf-heart",
   "http://archive.ics.uci.edu/ml/datasets/SPECTF+Heart",

--- a/src/data/classification/statlog-project-german-credit.jl
+++ b/src/data/classification/statlog-project-german-credit.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "statlog-project-german-credit",
   "http://archive.ics.uci.edu/ml/datasets/Statlog+Project",

--- a/src/data/classification/statlog-project-landsat-satellite.jl
+++ b/src/data/classification/statlog-project-landsat-satellite.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "statlog-project-landsat-satellite",
   "http://archive.ics.uci.edu/ml/datasets/Statlog+Project",

--- a/src/data/classification/teaching-assistant-evaluation.jl
+++ b/src/data/classification/teaching-assistant-evaluation.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "teaching-assistant-evaluation",
   "http://archive.ics.uci.edu/ml/datasets/Teaching+Assistant+Evaluation",

--- a/src/data/classification/thoracic-surgery.jl
+++ b/src/data/classification/thoracic-surgery.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "thoracic-surgery",
   "http://archive.ics.uci.edu/ml/datasets/Thoracic+Surgery+Data",

--- a/src/data/classification/thyroid-disease-allbp.jl
+++ b/src/data/classification/thyroid-disease-allbp.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "thyroid-disease-allbp",
   "http://archive.ics.uci.edu/ml/datasets/Thyroid+Disease",

--- a/src/data/classification/thyroid-disease-allhyper.jl
+++ b/src/data/classification/thyroid-disease-allhyper.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "thyroid-disease-allhyper",
   "http://archive.ics.uci.edu/ml/datasets/Thyroid+Disease",

--- a/src/data/classification/thyroid-disease-allhypo.jl
+++ b/src/data/classification/thyroid-disease-allhypo.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "thyroid-disease-allhypo",
   "http://archive.ics.uci.edu/ml/datasets/Thyroid+Disease",

--- a/src/data/classification/thyroid-disease-allrep.jl
+++ b/src/data/classification/thyroid-disease-allrep.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "thyroid-disease-allrep",
   "http://archive.ics.uci.edu/ml/datasets/Thyroid+Disease",

--- a/src/data/classification/thyroid-disease-ann-thyroid.jl
+++ b/src/data/classification/thyroid-disease-ann-thyroid.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "thyroid-disease-ann-thyroid",
   "http://archive.ics.uci.edu/ml/datasets/Thyroid+Disease",

--- a/src/data/classification/thyroid-disease-dis.jl
+++ b/src/data/classification/thyroid-disease-dis.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "thyroid-disease-dis",
   "http://archive.ics.uci.edu/ml/datasets/Thyroid+Disease",

--- a/src/data/classification/thyroid-disease-new-thyroid.jl
+++ b/src/data/classification/thyroid-disease-new-thyroid.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "thyroid-disease-new-thyroid",
   "http://archive.ics.uci.edu/ml/datasets/Thyroid+Disease",

--- a/src/data/classification/thyroid-disease-sick-euthyroid.jl
+++ b/src/data/classification/thyroid-disease-sick-euthyroid.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "thyroid-disease-sick-euthyroid",
   "http://archive.ics.uci.edu/ml/datasets/Thyroid+Disease",

--- a/src/data/classification/thyroid-disease-sick.jl
+++ b/src/data/classification/thyroid-disease-sick.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "thyroid-disease-sick",
   "http://archive.ics.uci.edu/ml/datasets/Thyroid+Disease",

--- a/src/data/classification/thyroid-disease-thyroid-0387.jl
+++ b/src/data/classification/thyroid-disease-thyroid-0387.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "thyroid-disease-thyroid-0387",
   "http://archive.ics.uci.edu/ml/datasets/Thyroid+Disease",

--- a/src/data/classification/tic-tac-toe-endgame.jl
+++ b/src/data/classification/tic-tac-toe-endgame.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "tic-tac-toe-endgame",
   "http://archive.ics.uci.edu/ml/datasets/Tic-Tac-Toe+Endgame",

--- a/src/data/classification/trains.jl
+++ b/src/data/classification/trains.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "trains",
   "http://archive.ics.uci.edu/ml/datasets/Trains",

--- a/src/data/classification/wall-following-robot-navigation-2.jl
+++ b/src/data/classification/wall-following-robot-navigation-2.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "wall-following-robot-navigation-2",
   "http://archive.ics.uci.edu/ml/datasets/Wall-Following+Robot+Navigation+Data",

--- a/src/data/classification/wall-following-robot-navigation-24.jl
+++ b/src/data/classification/wall-following-robot-navigation-24.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "wall-following-robot-navigation-24",
   "http://archive.ics.uci.edu/ml/datasets/Wall-Following+Robot+Navigation+Data",

--- a/src/data/classification/wall-following-robot-navigation-4.jl
+++ b/src/data/classification/wall-following-robot-navigation-4.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "wall-following-robot-navigation-4",
   "http://archive.ics.uci.edu/ml/datasets/Wall-Following+Robot+Navigation+Data",

--- a/src/data/classification/wine.jl
+++ b/src/data/classification/wine.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "wine",
   "http://archive.ics.uci.edu/ml/datasets/Wine",

--- a/src/data/classification/yeast.jl
+++ b/src/data/classification/yeast.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "yeast",
   "http://archive.ics.uci.edu/ml/datasets/Yeast",

--- a/src/data/classification/zoo.jl
+++ b/src/data/classification/zoo.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "zoo",
   "http://archive.ics.uci.edu/ml/datasets/Zoo",

--- a/src/data/regression/abalone.jl
+++ b/src/data/regression/abalone.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "abalone",
   "https://archive.ics.uci.edu/ml/datasets/Abalone",

--- a/src/data/regression/ailerons.jl
+++ b/src/data/regression/ailerons.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "ailerons",
   "https://www.openml.org/d/296",

--- a/src/data/regression/airfoil-self-noise.jl
+++ b/src/data/regression/airfoil-self-noise.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "airfoil-self-noise",
   "https://archive.ics.uci.edu/ml/datasets/Airfoil+Self-Noise",

--- a/src/data/regression/airline-costs.jl
+++ b/src/data/regression/airline-costs.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "airline-costs",
   "http://www.stat.ufl.edu/~winner/data/airline_costs.txt",

--- a/src/data/regression/auto-mpg.jl
+++ b/src/data/regression/auto-mpg.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "auto-mpg",
   "https://archive.ics.uci.edu/ml/datasets/Auto+MPG",

--- a/src/data/regression/automobile.jl
+++ b/src/data/regression/automobile.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "automobile",
   "https://archive.ics.uci.edu/ml/datasets/Automobile",

--- a/src/data/regression/beer-aroma.jl
+++ b/src/data/regression/beer-aroma.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "beer-aroma",
   "http://www.stat.ufl.edu/~winner/data/aroma_beer.txt",

--- a/src/data/regression/blog-feedback.jl
+++ b/src/data/regression/blog-feedback.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "blog-feedback",
   "https://archive.ics.uci.edu/ml/datasets/BlogFeedback",

--- a/src/data/regression/communities-and-crime-2.jl
+++ b/src/data/regression/communities-and-crime-2.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "communities-and-crime-2",
   "https://archive.ics.uci.edu/ml/datasets/Communities+and+Crime+Unnormalized",

--- a/src/data/regression/communities-and-crime.jl
+++ b/src/data/regression/communities-and-crime.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "communities-and-crime",
   "https://archive.ics.uci.edu/ml/datasets/Communities+and+Crime",

--- a/src/data/regression/computer-hardware.jl
+++ b/src/data/regression/computer-hardware.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "computer-hardware",
   "https://archive.ics.uci.edu/ml/datasets/Computer+Hardware",

--- a/src/data/regression/concrete-slump-test-compressive.jl
+++ b/src/data/regression/concrete-slump-test-compressive.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "concrete-slump-test-compressive",
   "https://archive.ics.uci.edu/ml/datasets/Concrete+Slump+Test",

--- a/src/data/regression/concrete-slump-test-flow.jl
+++ b/src/data/regression/concrete-slump-test-flow.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "concrete-slump-test-flow",
   "https://archive.ics.uci.edu/ml/datasets/Concrete+Slump+Test",

--- a/src/data/regression/concrete-slump-test-slump.jl
+++ b/src/data/regression/concrete-slump-test-slump.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "concrete-slump-test-slump",
   "https://archive.ics.uci.edu/ml/datasets/Concrete+Slump+Test",

--- a/src/data/regression/construction-maintenance.jl
+++ b/src/data/regression/construction-maintenance.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "construction-maintenance",
   "http://www.stat.ufl.edu/~winner/data/const_maint.txt",

--- a/src/data/regression/cpu-act.jl
+++ b/src/data/regression/cpu-act.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "cpu-act",
   "https://www.openml.org/d/197",

--- a/src/data/regression/cpu-small.jl
+++ b/src/data/regression/cpu-small.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "cpu-small",
   "https://www.openml.org/d/227",

--- a/src/data/regression/elevators.jl
+++ b/src/data/regression/elevators.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "elevators",
   "https://www.openml.org/d/216",

--- a/src/data/regression/forest-fires.jl
+++ b/src/data/regression/forest-fires.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "forest-fires",
   "https://archive.ics.uci.edu/ml/datasets/Forest+Fires",

--- a/src/data/regression/geographic-origin-music.jl
+++ b/src/data/regression/geographic-origin-music.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "geographic-origin-music",
   "https://archive.ics.uci.edu/ml/datasets/Geographical+Original+of+Music",

--- a/src/data/regression/home-mortgage.jl
+++ b/src/data/regression/home-mortgage.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "home-mortgage",
   "http://www.stat.ufl.edu/~winner/data/myield.txt",

--- a/src/data/regression/housing.jl
+++ b/src/data/regression/housing.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "housing",
   "https://archive.ics.uci.edu/ml/datasets/Housing",

--- a/src/data/regression/hybrid-price.jl
+++ b/src/data/regression/hybrid-price.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "hybrid-price",
   "http://www.stat.ufl.edu/~winner/data/hybrid_reg.txt",

--- a/src/data/regression/immigrant-salaries.jl
+++ b/src/data/regression/immigrant-salaries.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "immigrant-salaries",
   "http://www.stat.ufl.edu/~winner/data/immwork.txt",

--- a/src/data/regression/insurance-company-benchmark.jl
+++ b/src/data/regression/insurance-company-benchmark.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "insurance-company-benchmark",
   "https://archive.ics.uci.edu/ml/datasets/Insurance+Company+Benchmark+%28COIL+2000%29",

--- a/src/data/regression/japan-emmigration.jl
+++ b/src/data/regression/japan-emmigration.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "japan-emmigration",
   "http://www.stat.ufl.edu/~winner/data/japanemg.txt",

--- a/src/data/regression/kin8nm.jl
+++ b/src/data/regression/kin8nm.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "kin8nm",
   "https://www.openml.org/d/189",

--- a/src/data/regression/lpga-2008.jl
+++ b/src/data/regression/lpga-2008.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "lpga-2008",
   "http://www.stat.ufl.edu/~winner/data/lpga2008.txt",

--- a/src/data/regression/lpga-2009.jl
+++ b/src/data/regression/lpga-2009.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "lpga-2009",
   "http://www.stat.ufl.edu/~winner/data/lpga2009.txt",

--- a/src/data/regression/online-news-popularity.jl
+++ b/src/data/regression/online-news-popularity.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "online-news-popularity",
   "https://archive.ics.uci.edu/ml/datasets/Online+News+Popularity",

--- a/src/data/regression/parkinsons-telemonitoring-motor.jl
+++ b/src/data/regression/parkinsons-telemonitoring-motor.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "parkinsons-telemonitoring-motor",
   "https://archive.ics.uci.edu/ml/datasets/Parkinsons+Telemonitoring",

--- a/src/data/regression/parkinsons-telemonitoring-total.jl
+++ b/src/data/regression/parkinsons-telemonitoring-total.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "parkinsons-telemonitoring-total",
   "https://archive.ics.uci.edu/ml/datasets/Parkinsons+Telemonitoring",

--- a/src/data/regression/pyrim.jl
+++ b/src/data/regression/pyrim.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "pyrim",
   "https://www.openml.org/d/217",

--- a/src/data/regression/texas-jan-temp.jl
+++ b/src/data/regression/texas-jan-temp.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "texas-jan-temp",
   "http://www.stat.ufl.edu/~winner/data/texas1.txt",

--- a/src/data/regression/triazines.jl
+++ b/src/data/regression/triazines.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "triazines",
   "https://www.openml.org/d/206",

--- a/src/data/regression/tv-sales.jl
+++ b/src/data/regression/tv-sales.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "tv-sales",
   "http://www.stat.ufl.edu/~winner/data/tvsales.txt",

--- a/src/data/regression/vote-for-clinton.jl
+++ b/src/data/regression/vote-for-clinton.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "vote-for-clinton",
   "http://www.stat.ufl.edu/~winner/data/clinton1.txt",

--- a/src/data/regression/wiki4he.jl
+++ b/src/data/regression/wiki4he.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "wiki4he",
   "https://archive.ics.uci.edu/ml/datasets/wiki4HE",

--- a/src/data/regression/wine-quality-red.jl
+++ b/src/data/regression/wine-quality-red.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "wine-quality-red",
   "https://archive.ics.uci.edu/ml/datasets/Wine+Quality",

--- a/src/data/regression/wine-quality-white.jl
+++ b/src/data/regression/wine-quality-white.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "wine-quality-white",
   "https://archive.ics.uci.edu/ml/datasets/Wine+Quality",

--- a/src/data/regression/yacht-hydrodynamics.jl
+++ b/src/data/regression/yacht-hydrodynamics.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "yacht-hydrodynamics",
   "https://archive.ics.uci.edu/ml/datasets/Yacht+Hydrodynamics",

--- a/src/data/regression/year-prediction-msd.jl
+++ b/src/data/regression/year-prediction-msd.jl
@@ -1,5 +1,3 @@
-using DataDeps
-
 register(DataDep(
   "year-prediction-msd",
   "http://archive.ics.uci.edu/ml/datasets/YearPredictionMSD",


### PR DESCRIPTION
Currently, I get
```julia
ERROR: LoadError: InitError: LoadError: Evaluation into the closed module `UCIData` breaks incremental compilation because the side effects will not be permanent. This is likely due to some other module mutating `UCIData` with `eval` during precompilation - don't do this.
Stacktrace:
  [1] include(mod::Module, _path::String)
    @ Base ./Base.jl:457
  [2] include
    @ ~/.julia/packages/UCIData/MCrM5/src/UCIData.jl:1 [inlined]
  [3] __init__()
    @ UCIData ~/.julia/packages/UCIData/MCrM5/src/UCIData.jl:45
  [4] register_restored_modules(sv::Core.SimpleVector, pkg::Base.PkgId, path::String)
    @ Base ./loading.jl:1115
  [5] _include_from_serialized(pkg::Base.PkgId, path::String, ocachepath::String, depmods::Vector{Any})
    @ Base ./loading.jl:1061
  [6] _require_search_from_serialized(pkg::Base.PkgId, sourcepath::String, build_id::UInt128)
    @ Base ./loading.jl:1506
  [7] _require(pkg::Base.PkgId, env::String)
    @ Base ./loading.jl:1783
  [8] _require_prelocked(uuidkey::Base.PkgId, env::String)
    @ Base ./loading.jl:1660
  [9] macro expansion
    @ ./loading.jl:1648 [inlined]
 [10] macro expansion
    @ ./lock.jl:267 [inlined]
 [11] require(into::Module, mod::Symbol)
    @ Base ./loading.jl:1611
 [12] include
    @ ./Base.jl:457 [inlined]
 [13] include_package_for_output(pkg::Base.PkgId, input::String, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String}, concrete_deps::Vector{Pair{Base.PkgId, UInt128}}, source::Nothing)
    @ Base ./loading.jl:2049
 [14] top-level scope
    @ stdin:3
in expression starting at /Users/eph/.julia/packages/UCIData/MCrM5/src/data/classification/acute-inflammations-1.jl:1
during initialization of module UCIData
```

when precompiling a package that includes UCIData. I believe the issue is we shouldn't call `include` at `__init__` time, even though we want to call `register` at `__init__` time. Here, I do a small change so our `register` pushes registration calls into a global so that we can call them at `__init__` time.